### PR TITLE
Require setuptools 61+ for pyproject.toml support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This is required for 3993dcaa5366da9d771575e8735dd5a7a2c13894

See https://setuptools.pypa.io/en/latest/history.html#v61-0-0